### PR TITLE
Disabled navigation to login page after logging in

### DIFF
--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -2,6 +2,7 @@
 /*Modified by Nakshatra Bhandary (16/6/26) and (17/6/25) to connect to the backend*/
 /*Modified by Nakshatra Bhandary 23/6/25 to add forgot password*/
 /*Updated by Nikita S Raj Kapini on 24/06/2025*/
+/*Modified by Nakshatra on 26/6/25 to prevent navigation to login page after loggin in*/
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
@@ -18,12 +19,16 @@ const LoginPage: React.FC = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      navigate('/dashboard'); // redirect if already logged in
+    }
     // Disable scrolling
     document.body.style.overflow = 'hidden';
     return () => {
       document.body.style.overflow = 'auto';
     };
-  }, []);
+  }, [navigate]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
After logging in the user could navigate back to the login page and login again using a different ID. This would cause an automatic logout in the other session which could have future scalability issues. Thus the option to navigate to login page is enabled only if the user has not yet logged in.